### PR TITLE
Added CopyInputStream to ensure that the AspNetCore owinContext does …

### DIFF
--- a/src/IdentityServer3.Integration.AspNetCore/CopyInputStream.cs
+++ b/src/IdentityServer3.Integration.AspNetCore/CopyInputStream.cs
@@ -1,0 +1,34 @@
+using Microsoft.Owin;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IdentityServer3.Integration.AspNetCore
+{
+    internal class CopyInputStream
+    {
+        readonly Func<IDictionary<string, object>, Task> _next;
+
+        public CopyInputStream(Func<IDictionary<string, object>, Task> next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(IDictionary<string, object> env)
+        {
+            var context = new OwinContext(env);
+
+            Stream oldStream = context.Request.Body;
+            var body = new StreamReader(context.Request.Body).ReadToEnd();
+            var requestData = Encoding.UTF8.GetBytes(body);
+            context.Request.Body = new MemoryStream(requestData);
+
+            await _next(env);
+
+            context.Request.Body = oldStream;
+        }
+    }
+}

--- a/src/IdentityServer3.Integration.AspNetCore/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer3.Integration.AspNetCore/IdentityServerApplicationBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Owin;
 
 namespace Microsoft.AspNetCore.Builder
 {
+    using IdentityServer3.Integration.AspNetCore;
     using DataProtectionProviderDelegate = Func<string[], Tuple<Func<byte[], byte[]>, Func<byte[], byte[]>>>;
     using DataProtectionTuple = Tuple<Func<byte[], byte[]>, Func<byte[], byte[]>>;
 
@@ -26,6 +27,8 @@ namespace Microsoft.AspNetCore.Builder
                         var dataProtection = provider.CreateProtector(String.Join(",", purposes));
                         return new DataProtectionTuple(dataProtection.Protect, dataProtection.Unprotect);
                     });
+
+                    builder.Use<CopyInputStream>();
 
                     builder.UseIdentityServer(options);
 


### PR DESCRIPTION
…not change from IdSrv and become nulled out

This should resolve Broken Login and Logout Behavior with RTM Update #10