### PR TITLE
Update .NET Core dependencies to v1.1.0

### DIFF
--- a/src/IdentityServer3.Integration.AspNetCore/project.json
+++ b/src/IdentityServer3.Integration.AspNetCore/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "IdentityServer3 Integration Library for ASP.NET Core",
   "authors": [ "Dominick Baier & Brock Allen" ],
   "packOptions": {
@@ -13,8 +13,8 @@
       "dependencies": {
         "IdentityServer3": "2.1.1",
         "Microsoft.Owin": "3.0.1",
-        "Microsoft.AspNetCore.DataProtection": "1.0.0",
-        "Microsoft.AspNetCore.Owin": "1.0.0"
+        "Microsoft.AspNetCore.DataProtection": "1.1.0",
+        "Microsoft.AspNetCore.Owin": "1.1.0"
       }
     }
   }


### PR DESCRIPTION
This commit fixes #12 by updating the referenced .NET Core dependencies to
v1.1.0 and correspondingly bumping the version of this library to v1.1.0.